### PR TITLE
Fix model loading error

### DIFF
--- a/src/components/Avatar3D.tsx
+++ b/src/components/Avatar3D.tsx
@@ -17,7 +17,7 @@ const AvatarModel: React.FC = () => {
   const [clickAnimation, setClickAnimation] = useState(0);
   
   // Load the 3D model
-  const { scene, animations } = useGLTF('/model.glb');
+  const { scene, animations } = useGLTF(`${process.env.PUBLIC_URL}/model.glb`);
   const { actions } = useAnimations(animations, avatarRef);
   
   useEffect(() => {


### PR DESCRIPTION
Update 3D model path to use `PUBLIC_URL` to resolve loading errors on GitHub Pages.

The application was failing to load `/model.glb` because it was requesting an incorrect absolute path, especially when deployed to a subdirectory on GitHub Pages. This resulted in a 404 HTML page being returned instead of the GLB file. Using `process.env.PUBLIC_URL` ensures the correct base path is applied, allowing the model to load successfully in both development and production environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-b80b84fc-156e-4b62-a49c-c7b6926fefb6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b80b84fc-156e-4b62-a49c-c7b6926fefb6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

